### PR TITLE
Reusing the karma server on recompile

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,11 +9,13 @@ class KarmaPlugin {
   }
 
   onCompile() {
-    if (this.config) {
+    if (this.config && !this.server) {
       //start karma
-      new Server(this.config).start();
+      this.server = new Server(this.config);
+      this.server.start();
     }
   }
+
 }
 
 KarmaPlugin.prototype.brunchPlugin = true;

--- a/test.js
+++ b/test.js
@@ -113,4 +113,16 @@ describe('Plugin', () => {
       expect(plugin).to.be.ok;
     });
   })
+  describe('Karma server', () => {
+    before(() => {
+      plugin = new Plugin(getConfig(karmaConf));
+      plugin.onCompile();
+    });
+    it('should not be recreated on each compile', () => {
+      let server = plugin.server;
+
+      plugin.onCompile();
+      expect(plugin.server).to.equal(server);
+    });
+  })
 });


### PR DESCRIPTION
It looks like the primary use case in the initial version was to use with `brunch build`.  There was a bug in using `brunch watch` however, as a new karma server was spawned per compile.

This PR reuses the karma service once it is started, so that you can use `brunch watch` with `singleRun: false`.
