### PR TITLE
Run only in test environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Or, do manual install:
 * If you want to use git version of plugin, use the GitHub URI
 `"karma-brunch": "denar90/karma-brunch"`.
 
+And run brunch with the test environment. For instance `brunch watch --env=test`
+
 ###Config example with karma
 ```javascript
 

--- a/index.js
+++ b/index.js
@@ -20,5 +20,6 @@ class KarmaPlugin {
 
 KarmaPlugin.prototype.brunchPlugin = true;
 KarmaPlugin.prototype.extension = 'js';
+KarmaPlugin.prototype.defaultEnv = 'test';
 
 module.exports = KarmaPlugin;


### PR DESCRIPTION
I was using this plugin and noticed that it starts the karma server when running brunch normally with `brunch watch --server`. Since it's for test purposes I believe that make sense to run it under the test environment. What do you think?
